### PR TITLE
New script for Open Data Survey sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.org-DONE/
+*.org/

--- a/download-static-site.sh
+++ b/download-static-site.sh
@@ -82,4 +82,4 @@ echo "Delete local folder"
 mv $DOMAIN_NAME "${DOMAIN_NAME}-DONE"
 
 echo "Set up CNAME record"
-python update_cname_records.py $BUCKET_NAME false
+python update_cname_records.py $BUCKET_NAME c.storage.googleapis.com false

--- a/download-static-site.sh
+++ b/download-static-site.sh
@@ -82,4 +82,4 @@ echo "Delete local folder"
 mv $DOMAIN_NAME "${DOMAIN_NAME}-DONE"
 
 echo "Set up CNAME record"
-python update_cname_records.py $BUCKET_NAME c.storage.googleapis.com false
+python update_cname_records.py $BUCKET_NAME c.storage.googleapis.com 0

--- a/download-static-site.sh
+++ b/download-static-site.sh
@@ -54,6 +54,9 @@ fi
 echo "Updating http to https in all site files"
 find ./$DOMAIN_NAME -type f -print0 | xargs -0 sed -i 's/http:\/\//https:\/\//g'
 
+echo "Removing all 'login' links"
+find ./$DOMAIN_NAME -type f -print0 | xargs -0 sed -ri "s/<a\ (.*)>Login(.*)<\/a>//g"
+
 echo "Upload files"
 gsutil -m cp -r $DOMAIN_NAME/** gs://$BUCKET_NAME
 

--- a/download-static-site.sh
+++ b/download-static-site.sh
@@ -82,4 +82,4 @@ echo "Delete local folder"
 mv $DOMAIN_NAME "${DOMAIN_NAME}-DONE"
 
 echo "Set up CNAME record"
-python update_cname_records.py $BUCKET_NAME
+python update_cname_records.py $BUCKET_NAME false

--- a/download-static-site.sh
+++ b/download-static-site.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Download a static version of a site
+# Create a bucket and upload these files
+# Make the contents of a bucket public on the internet and
+# create a DNS record for it
+#
+
+set -e
+DOMAIN_NAME=$1
+PROTOCOL=$2
+ALREADY_DOWNLOADED=${3:-false}
+
+if [ -z $DOMAIN_NAME ]; then
+    echo "Usage: ./download-static-site.sh DOMAIN_NAME [PROTOCOL (http | https)]"
+    exit 1
+fi
+
+if [ -z $PROTOCOL ]; then
+     PROTOCOL="http"
+fi
+
+if [ $ALREADY_DOWNLOADED = "false" ]; then
+     echo "Downloading $DOMAIN_NAME ..."
+     URL="$PROTOCOL://$DOMAIN_NAME"
+
+     wget \
+          -t 2 \
+          --recursive \
+          --no-clobber \
+          --page-requisites \
+          --html-extension \
+          --convert-links \
+          --restrict-file-names=windows \
+          --domains $DOMAIN_NAME \
+          --no-parent $URL
+fi
+
+BUCKET_NAME=$DOMAIN_NAME
+
+echo "Check gcloud credentials"
+./check_gcloud_login.sh
+
+echo "Check if bucket '$BUCKET_NAME' exists"
+BUCKET_EXIST=`gsutil ls -L -b gs://$BUCKET_NAME` || BUCKET_EXIST=false
+echo " - BUCKET_EXIST = '$BUCKET_EXIST'"
+if [ "$BUCKET_EXIST" = "false" ]; then
+    echo "Bucket don't exits, creating the bucket in oki-archive"
+    gsutil mb -l eu -p oki-archive gs://$BUCKET_NAME
+else
+    echo "Bucket is located in oki-archive"
+fi
+
+echo "Updating http to https in all site files"
+find ./$DOMAIN_NAME -type f -print0 | xargs -0 sed -i 's/http:\/\//https:\/\//g'
+
+echo "Upload files"
+gsutil -m cp -r $DOMAIN_NAME/** gs://$BUCKET_NAME
+
+echo "Set public permissions"
+gsutil iam ch allUsers:objectViewer gs://$BUCKET_NAME
+
+echo "Set website properties"
+gsutil web set -m index.html gs://$BUCKET_NAME
+
+echo "Modify index.html"
+./process_index.html.sh $BUCKET_NAME
+
+# Avoid conflict with the "update_cname_records" script
+echo "Delete local folder"
+rm -rf $DOMAIN_NAME
+
+echo "Set up CNAME record"
+python update_cname_records.py $BUCKET_NAME

--- a/process_index.html.sh
+++ b/process_index.html.sh
@@ -23,3 +23,6 @@ sed -ri "s/analyticsTrackingID: (.*)//g" index.html
 
 echo "Re-upload file"
 gsutil cp index.html gs://$BUCKET_NAME/index.html
+
+echo "Remove index.html file"
+rm index.html

--- a/update_cname_records.py
+++ b/update_cname_records.py
@@ -77,13 +77,14 @@ if __name__ == "__main__":
     if len(sys.argv) > 2:
         # usually k8s-production.openknowledge.io (not proxied)
         new_record_content=sys.argv[2]
-        # false for k8s-production.openknowledge.io, True for c.storage.googleapis.com (default)
-        proxied=bool(int(sys.argv[3]))
     else:
         # Default is moving to oki-archive
         new_record_content=RECORD_CONTENT
-        proxied = True
 
+    proxied = True  # default
+    if len(sys.argv) > 3:
+        proxied=bool(int(sys.argv[3]))
+    
     if os.path.exists(domains_input):
         with open(domains_input, "r") as f:
             domains = [l.strip() for l in f.readlines()]

--- a/update_cname_records.py
+++ b/update_cname_records.py
@@ -74,7 +74,7 @@ def update_cname_record(domain, new_record_content, proxied):
 if __name__ == "__main__":
 
     domains_input = sys.argv[1]
-    if len(sys.argv) > 1:
+    if len(sys.argv) > 2:
         # usually k8s-production.openknowledge.io (not proxied)
         new_record_content=sys.argv[2]
         # false for k8s-production.openknowledge.io, True for c.storage.googleapis.com (default)


### PR DESCRIPTION
This PR:
 - Add a new script to download a full site, move to `oki-archive` bucke and redirect DNS records
 - Allow the update dns recordfs script to be more flexible. 
