### PR TITLE
Archive repo script and docs

### DIFF
--- a/archive-github-repos/README.md
+++ b/archive-github-repos/README.md
@@ -1,3 +1,28 @@
 # Archive old GitHub repositories
 
-Scan all GitHub repositories within an organization.  
+With a GitHub token you'll be able to run api.github.com requests.  
+References:
+ - Creating access token: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
+ - Create a token for your user (including organizations) https://github.com/settings/personal-access-tokens/new
+ - Fine grained permission URLs: https://docs.github.com/en/rest/overview/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#administration
+ - `PATCH` to update a repository https://docs.github.com/en/rest/repos/repos#update-a-repository
+
+# Required grained permission: Administration repo
+
+## Scan all GitHub repositories within an organization.  
+
+```
+python get-all-org-repos.py $ORG_NAME $GHG_TOKEN
+```
+
+## Archive a repository
+
+```
+python archive-repo.py $ORG_NAME $REPO_NAME $GHG_TOKEN
+```
+
+## Unarchive a repository
+
+```
+python archive-repo.py $ORG_NAME $REPO_NAME $GHG_TOKEN 0
+```

--- a/archive-github-repos/archive-repo.py
+++ b/archive-github-repos/archive-repo.py
@@ -1,0 +1,47 @@
+import json
+import os
+import requests
+import sys
+
+
+if len(sys.argv) < 3:
+    print(f"Usage python archi-repo.py ORG_NAME REPO_NAME GITHUB_TOKEN [ARCHIVE(1|0) default 1]")
+
+ORG_NAME = sys.argv[1]
+REPO_NAME = sys.argv[2]
+GITHUB_TOKEN = sys.argv[3]
+ARCHIVE = "1" if len(sys.argv) < 5 else sys.argv[4]
+if ARCHIVE not in ["0", "1"]:
+    print(f"ARCHIVE must be 0 or 1, got {ARCHIVE}")
+    sys.exit(1)
+
+archive = ARCHIVE == "1"
+
+headers = {
+    "accept": "application/vnd.github+json",
+    "owner": ORG_NAME,
+    "repo": REPO_NAME,
+    "Authorization": f"token {GITHUB_TOKEN}"
+}
+
+data = {
+    "archived": archive
+}
+# Define URL to archive repo with API
+url = f"https://api.github.com/repos/{ORG_NAME}/{REPO_NAME}"
+
+if archive:
+    print(f"Archiving repo {ORG_NAME}/{REPO_NAME}")
+else:
+    print(f"Unarchiving repo {ORG_NAME}/{REPO_NAME}")
+
+response = requests.patch(url, headers=headers, data=json.dumps(data))
+data = response.json()
+# The response do not tell if the action ran successfully, it just
+# returns the current state of the repo
+# print(f" response {data}")
+if data['archived'] == archive:
+    if archive:
+        print("Repo archived successfully")
+    else:
+        print("Repo unarchived successfully")


### PR DESCRIPTION
Related to [Devops#312](https://github.com/okfn/devops/issues/312)

This PR:
 - Adds a new script to archive/unarchive any GitHub repo
 - Adds documentation

I manage to archive/unarchive repos with this script. It'll be easy to run a bulk archive repos from our [repositories list](https://docs.google.com/spreadsheets/d/1vF_r9OIKgzrOXTTp-IFz8u_eZKPnk2VjMi3S1-EJMgA/edit#gid=0)

I count days without push and days without update. I we archive repositories without pushes or updates in the last 4 years, we get:
 - To Archive **226**
 - To preserve **149**

I plan not to add a deprecation notice because probably it will be problematic to write in the default (probably protected) branch.

If we plan to do this monthly/yearly, I can create a script to iterate all repositories and automatically archive them based on its age.